### PR TITLE
feat: add decorators and first bot example

### DIFF
--- a/examples/simple_bot_handler/README.md
+++ b/examples/simple_bot_handler/README.md
@@ -1,0 +1,28 @@
+# Simple Bot Handler
+
+The example in this directory shows how you can implement a bot command handler
+
+## How to run this example
+
+To run the bot you'll need a valid `BOT_TOKEN` that you can obtain from Telegram's BotFather and a running
+MongoDB instance.
+
+1. Run an instance of MongoDB with Docker:
+    ```bash
+    docker run -d --name mongodb -p 27017:27017 mongo
+    ```
+
+2. Export your BOT_TOKEN as an environment variable:
+    ```bash
+    export BOT_TOKEN="<your bot token>"
+    ```
+    or on Windows:
+    ```bash
+    set BOT_TOKEN="<your bot token>"
+    ```
+
+3. Install py-bot-starter and run the example:
+    ```bash
+    pip install py-bot-starter
+    python main.py
+    ```

--- a/examples/simple_bot_handler/main.py
+++ b/examples/simple_bot_handler/main.py
@@ -1,0 +1,23 @@
+import logging
+
+from telebot import types
+
+from botstarter import bot
+from botstarter.decorators import user_handler
+
+logging.basicConfig(level=logging.INFO)
+
+
+@user_handler(commands=["test"])
+def test_handler(msg, user, **kwargs):
+    bot.send_message(
+        msg.chat.id,
+        text=f"Hello {user.first_name}\nEcho: {msg.text}"
+    )
+
+
+if __name__ == '__main__':
+    bot.set_my_commands([
+        types.BotCommand(command="test", description="Tests this bot")
+    ])
+    bot.start()

--- a/src/botstarter/bot.py
+++ b/src/botstarter/bot.py
@@ -1,10 +1,11 @@
 import logging
 import os
 from time import sleep
+from typing import List, Optional
 
 import telebot
 from requests.exceptions import ReadTimeout
-from telebot.types import BotCommand
+from telebot import types
 
 from botstarter.common import str2mdown
 from botstarter.db.medias import create_media, get_media_by_path
@@ -177,17 +178,21 @@ def delete_message(message=None, chat_id=None, message_id=None, timeout=20):
         raise Exception("Both message and (chat_id,message_id) are None. One must be defined to delete the message.")
 
 
-def __gen_commands_global():
-    # todo: BotCommands should be provided by the implementing project
-    return [
-        BotCommand("testme", "Start a new game"),
-        BotCommand("help", "Show help string"),
-        BotCommand("start", "Show welcome message"),
-    ]
+def set_my_commands(commands: List[types.BotCommand],
+                    scope: Optional[types.BotCommandScope] = None,
+                    language_code: Optional[str] = None) -> bool:
+    return get_bot().set_my_commands(commands, scope, language_code)
 
 
-def send_set_commands():
-    get_bot().set_my_commands(
-        commands=__gen_commands_global(),
-        language_code=None
-    )
+def start():
+    """
+    Initialize the bot and start polling Telegram API for new messages.
+    """
+    from botstarter.db.base import init_db
+    init_db()
+
+    from botstarter.decorators import _init_decorators
+    _init_decorators()
+
+    logging.info("Starting Telegram bot!")
+    get_bot().infinity_polling()

--- a/src/botstarter/db/base.py
+++ b/src/botstarter/db/base.py
@@ -129,7 +129,7 @@ def init_db(host=None, port=None, database_name=None, auth=None):
     p_port = port or os.getenv("MONGODB_PORT", 27017)
     p_database_name = database_name or os.getenv("DATABASE_NAME", DEFAULT_DATABASE)
 
-    if not auth :
+    if not auth:
         if os.getenv("MONGODB_USERNAME") and os.getenv("MONGODB_PASSWORD"):
             auth = {
                 "username": os.getenv("MONGODB_USERNAME"),

--- a/src/botstarter/decorators.py
+++ b/src/botstarter/decorators.py
@@ -1,0 +1,157 @@
+import logging
+
+from botstarter.bot import answer_callback_query, delete_message, get_bot
+from botstarter.db.users import get_user_by_id, create_user, set_user_waiting_on, is_admin
+
+# todo: callback_action separator should be escaped and un-escaped if present in action string value
+CALLBACK_ACTION_SPLIT_SEPARATOR = "::"
+
+ALL_WAITING_ON_CALLBACKS = {}
+
+
+def admin_handler(commands):
+    """
+    Creates a new message handler for bot admin requests.
+
+    :param commands: the message handler commands
+    :return:
+    """
+
+    def function_decorator(func):
+        bot = get_bot()
+
+        @bot.message_handler(commands=commands)
+        def check_message_from_admin(*args, **kwargs):
+            msg = args[0]
+            user_id = msg.from_user.id
+            secure_chat_id = msg.from_user.id
+            user = get_user_by_id(msg.from_user.id)
+
+            logging.info(f"admin request from user with id {user_id}")
+            if user is not None and bool(user.is_admin):
+                logging.info(f"admin request GRANTED to user {user_id}")
+                return func(*args, user_id, secure_chat_id, **kwargs)
+            else:
+                logging.info(f"admin request was DENIED for user with id {user_id}")
+                return
+
+        return check_message_from_admin
+
+    return function_decorator
+
+
+def user_handler(*args, **kwargs):
+    """
+    Registers a message handler for user requests.
+
+    :return: the wrapper decorator function
+    """
+
+    def wrapper(wrapped_func):
+        bot = get_bot()
+
+        @bot.message_handler(*args, **kwargs)
+        def load_user_information(msg):
+            logging.debug("Received user request: %s", msg)
+
+            if msg.from_user.is_bot:
+                # do nothing if you receive a message from a bot
+                logging.debug("Received message from bot. Discarding. %s", msg)
+                return
+
+            user = get_user_by_id(msg.from_user.id)
+            if not user:
+                user = create_user(msg)
+
+            additional_args = {}
+            if user.waiting_on:
+                waiting_tokens = user.waiting_on.split(CALLBACK_ACTION_SPLIT_SEPARATOR)
+                additional_args['action_name'] = waiting_tokens[0]
+                additional_args['action_params'] = waiting_tokens[1:]
+                # remove waiting on option once read
+                set_user_waiting_on(msg.from_user.id, waiting_on=None)
+
+            return wrapped_func(msg, user, **additional_args)
+
+        return load_user_information
+
+    return wrapper
+
+
+def gen_callback_option(callback_action, label, *values):
+    payload = CALLBACK_ACTION_SPLIT_SEPARATOR.join(values)
+    ss = str(CALLBACK_ACTION_SPLIT_SEPARATOR)
+    action_string = f"{callback_action}{ss}{payload}"
+    return [label, action_string]
+
+
+def __unpack_callback_option(value):
+    tokens = value.split(CALLBACK_ACTION_SPLIT_SEPARATOR)
+    if len(tokens) >= 2:
+        callback_action = tokens[0]
+        values = tokens[1:]
+        return callback_action, values
+    else:
+        raise ValueError("Could not unpack callback option!")
+
+
+def callback_response(action, admin_only=False):
+    """
+    Registers a handler for the callback action specified in the parameters. It is also possible to secure the callback
+    handler for admin use only with the `admin_only` flag.
+
+    :param action: the callback action name
+    :param admin_only: callback function is restricted and can only be run in response to messages coming from admins. Default is `False`
+    :return: the decorator wrapper function
+    """
+
+    def wrapper(func):
+        bot = get_bot()
+
+        @bot.callback_query_handler(func=lambda call: call.data.startswith(f"{action}:"))
+        def read_callback_response(call):
+            logging.debug("Received callback action: %s", call)
+
+            callback_action, values = __unpack_callback_option(call.data)
+            logging.debug("Unpacked values for callback: action=%s, values=%s", callback_action, values)
+
+            user_id = call.from_user.id
+            if admin_only and not is_admin(user_id):
+                logging.warning(f"Received admin request from non-admin user with id {user_id}")
+                answer_callback_query(call)
+                delete_message(message=call.message)
+                return
+
+            user = get_user_by_id(user_id)
+
+            answer_callback_query(call)
+            return func(call, user, values)
+
+        return read_callback_response
+
+    return wrapper
+
+
+def user_msg_callback(action: str):
+    """
+    This decorator registers the decorated function as a message callback handler.
+
+    :param action: the name of the action the bot awaits from users
+    :return: the decorator wrapper function
+    """
+
+    def wrapper(func):
+        ALL_WAITING_ON_CALLBACKS[action] = func
+
+    return wrapper
+
+
+def _init_decorators():
+    @user_handler(func=lambda msg: True, content_types=["text"])
+    def catch_all(msg, user, waiting_on=None, waiting_on_params=None, **kwargs):
+        logging.debug("Running catch all. waiting_on=%s, waiting_on_params=%s, user=%d",
+                      waiting_on, waiting_on_params, user.get("id"))
+
+        if waiting_on is not None and waiting_on in ALL_WAITING_ON_CALLBACKS.keys():
+            func = ALL_WAITING_ON_CALLBACKS.get(waiting_on)
+            func(msg, user, waiting_on_params, **kwargs)


### PR DESCRIPTION
Include message handler decorators in this repo and a first example of how botstarter can be used to create a simple bot

Known Issues:
- handlers decorators have just been copy-pasted from antoher existing projects and haven't been tested. This is just a starting point, all the work still needs to be done
- created bot.start() function but with no option to supply configuration parameters